### PR TITLE
feat: auto-add suggested item

### DIFF
--- a/domus-frontend/src/app/listes/add-item-form/add-item-form.html
+++ b/domus-frontend/src/app/listes/add-item-form/add-item-form.html
@@ -4,6 +4,7 @@
          name="item"
          [(ngModel)]="newItemText"
          (input)="searchSuggestions()"
+         (change)="maybeAddSuggestion()"
          list="item-suggestions"
          placeholder="Ajouter un item">
   <datalist id="item-suggestions">

--- a/domus-frontend/src/app/listes/add-item-form/add-item-form.ts
+++ b/domus-frontend/src/app/listes/add-item-form/add-item-form.ts
@@ -46,4 +46,15 @@ export class AddItemForm {
       this.suggestions = data;
     });
   }
+
+  maybeAddSuggestion() {
+    const text = this.newItemText.trim();
+    const match = this.suggestions.find(s => s.text.toLowerCase() === text.toLowerCase());
+    if (match) {
+      this.itemService.addItem(this.listId, match.text).subscribe(() => {
+        this.newItemText = '';
+        this.suggestions = [];
+      });
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- auto-add items when selecting a suggestion

## Testing
- `PYTHONPATH=. pytest -q` *(fails: 404 Not Found and missing routes)*
- `npm test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_68ac10039c788320bcbc207121ea4fc7