### PR TITLE
feat(frontend): migrate add-form to signals

### DIFF
--- a/domus-frontend/src/app/listes/add-form/add-form.html
+++ b/domus-frontend/src/app/listes/add-form/add-form.html
@@ -3,26 +3,26 @@
     <input type="text"
            id="item-input"
            name="item"
-           [(ngModel)]="newItemText"
-           (input)="searchSuggestions()"
+           [ngModel]="newItemText()"
+           (ngModelChange)="newItemText.set($event)"
            (change)="maybeAddSuggestion()"
            list="item-suggestions"
            placeholder="Ajouter un item">
     <datalist id="item-suggestions">
-      @for (s of suggestions; track s.id) {
+      @for (s of suggestions(); track s.id) {
         <option [value]="s.text"></option>
       }
     </datalist>
   } @else {
-    <input type="text" [(ngModel)]="newName" name="name" placeholder="Nom de la liste">
+    <input type="text" [ngModel]="newName()" (ngModelChange)="newName.set($event)" name="name" placeholder="Nom de la liste">
     <input type="text"
-           [(ngModel)]="tagInput"
+           [ngModel]="tagInput()"
+           (ngModelChange)="tagInput.set($event)"
            name="tag"
-           (input)="searchSuggestions()"
            list="tag-suggestions"
            placeholder="Tag (ex: course, été)">
     <datalist id="tag-suggestions">
-      @for (t of tagSuggestions; track t) {
+      @for (t of suggestions(); track t) {
         <option [value]="t"></option>
       }
     </datalist>

--- a/domus-frontend/src/app/listes/add-form/add-form.ts
+++ b/domus-frontend/src/app/listes/add-form/add-form.ts
@@ -1,4 +1,4 @@
-import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {Component, EventEmitter, Input, Output, computed, effect, signal} from '@angular/core';
 import {FormsModule, NgForm} from '@angular/forms';
 import {Suggestion} from '../../models/interfaces';
 import {ItemService} from '../../core/services/item-service';
@@ -16,55 +16,51 @@ export class AddForm {
   @Input() listId: number = 0;
   @Output() add = new EventEmitter<{ name: string; tag: string }>();
 
-  newItemText: string = '';
-  suggestions: Suggestion[] = [];
-  newName: string = '';
-  tagInput: string = '';
-  tagSuggestions: string[] = [];
-
-  constructor(private itemService: ItemService, private tagService: TagService) {}
+  newItemText = signal('');
+  newName = signal('');
+  tagInput = signal('');
+  private itemSuggestions = signal<Suggestion[]>([]);
+  private tagSuggestions = signal<string[]>([]);
+  suggestions = computed(() => this.context === 'item' ? this.itemSuggestions() : this.tagSuggestions());
+  constructor(private itemService: ItemService, private tagService: TagService) {
+    effect(() => {
+      if (this.context === 'item') {
+        const q = this.newItemText().trim();
+        if (!q) {
+          this.itemSuggestions.set([]);
+          return;
+        }
+        this.itemService.searchSuggestions(this.listId, q).subscribe(data => this.itemSuggestions.set(data));
+      } else {
+        const q = this.tagInput().trim();
+        if (!q) {
+          this.tagSuggestions.set([]);
+          return;
+        }
+        this.tagService.searchSuggestions(q).subscribe(data => this.tagSuggestions.set(data));
+      }
+    });
+  }
 
   submit(form: NgForm) {
     if (this.context === 'item') {
-      const text = this.newItemText.trim();
+      const text = this.newItemText().trim();
       if (!text) {
         return;
       }
       this.itemService.addItem(this.listId, text).subscribe(() => {
         form.resetForm();
-        this.newItemText = '';
-        this.suggestions = [];
+        this.newItemText.set('');
+        this.itemSuggestions.set([]);
       });
     } else {
-      const name = this.newName.trim();
+      const name = this.newName().trim();
       if (!name) {
         return;
       }
-      this.add.emit({name, tag: this.tagInput || 'indefinie'});
+      this.add.emit({name, tag: this.tagInput() || 'indefinie'});
       form.resetForm();
-      this.tagSuggestions = [];
-    }
-  }
-
-  searchSuggestions() {
-    if (this.context === 'item') {
-      const q = this.newItemText.trim();
-      if (!q) {
-        this.suggestions = [];
-        return;
-      }
-      this.itemService.searchSuggestions(this.listId, q).subscribe(data => {
-        this.suggestions = data;
-      });
-    } else {
-      const q = this.tagInput.trim();
-      if (!q) {
-        this.tagSuggestions = [];
-        return;
-      }
-      this.tagService.searchSuggestions(q).subscribe(data => {
-        this.tagSuggestions = data;
-      });
+      this.tagSuggestions.set([]);
     }
   }
 
@@ -72,12 +68,12 @@ export class AddForm {
     if (this.context !== 'item') {
       return;
     }
-    const text = this.newItemText.trim();
-    const match = this.suggestions.find(s => s.text.toLowerCase() === text.toLowerCase());
+    const text = this.newItemText().trim();
+    const match = this.itemSuggestions().find(s => s.text.toLowerCase() === text.toLowerCase());
     if (match) {
       this.itemService.addItem(this.listId, match.text).subscribe(() => {
-        this.newItemText = '';
-        this.suggestions = [];
+        this.newItemText.set('');
+        this.itemSuggestions.set([]);
       });
     }
   }


### PR DESCRIPTION
## Summary
- rewrite add-form component to use Angular signals with computed suggestions and service effects
- update add-form template to bind to signals instead of async pipes

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68b85ca59ab083208394bec9f7ab9ed8